### PR TITLE
Fix toast listener leak

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -176,7 +176,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid adding duplicate listeners in `useToast`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*